### PR TITLE
fix: support proxy private repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ go_repos/*
 cacheDir/*
 .idea/*
 bin/
+.netrc
+.env

--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@
 
 A global proxy for go modules. see: [https://goproxy.io](https://goproxy.io)
 
+## Update
+
+本项目用来构建即刻内部的 goproxy 代理，封装了如下细节：
+
+- 通过 proxy 加速访问 github 私有 repo。
+- 使用 goproxy.cn 代理 golang 官方 sum.golang.org 的校验。
+- 增加一层 cache。
+
+用户在使用时只需要配置如下环境变量即可：
+
+```shell
+# GONOSUMDB 让 go cli 对于私有 repo 不校验 sumdb，必须在go get 前配置该变量
+# 必须将 GOPRIVATE 变量置为空（若已经为空不用处理），否则 go cli 将不会走 GOPROXY 拉取 GOPRIVATE 中定义的路径
+GOPRIVATE="" GONOSUMDB="github.com/iftechio" GOPROXY=http://goproxy.infra.svc.cluster.local:8081 go get -v github.com/iftechio/jike-sdk/go
+```
+
 ## Requirements
     It invokes the local go command to answer requests.
     The default cacheDir is GOPATH, you can set it up by yourself according to the situation.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,15 @@
 version: "2"
 services:
   goproxy:
-    image: goproxy/goproxy:latest
-    command: "-listen=0.0.0.0:8081 -cacheDir=/ext"
+    image: registry.cn-hangzhou.aliyuncs.com/iftech/goproxy:fix-env-d9e6dff
+    command: "-listen=0.0.0.0:8081 -cacheDir=/ext -proxy=https://goproxy.cn -exclude=github.com/iftechio"
+    environment:
+    - HTTPS_PROXY=http://jike:kYEwE4vnkMoJpWdaG]ANXxxNMenRC@47.52.119.148:4443
+    - HTTP_PROXY=http://jike:kYEwE4vnkMoJpWdaG]ANXxxNMenRC@47.52.119.148:4443
+    - NO_PROXY=goproxy.cn,mirrors.aliyun.com
+    # 本地开发可以从 jkdpy 上的 goproxy-config 找到对应的 token
+    - GITHUB_TOKEN_LOGIN=${GITHUB_TOKEN_LOGIN}
+    - GITHUB_TOKEN_PASSWORD=${GITHUB_TOKEN_PASSWORD}
     ports:
     - "8081:8081"
     restart: always

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/goproxyio/goproxy/v2/netrc"
 	"github.com/goproxyio/goproxy/v2/proxy"
 
 	"golang.org/x/mod/module"
@@ -73,6 +74,9 @@ func init() {
 
 	downloadRoot = getDownloadRoot()
 	os.Setenv("GOMODCACHE", downloadRoot)
+	if err := netrc.GenerateDotNetrcFile(); err != nil {
+		log.Fatalf("Failed to generate .netrc file, Error: %s", err.Error())
+	}
 }
 
 func main() {
@@ -140,6 +144,8 @@ func goJSON(dst interface{}, command ...string) error {
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	// 继承操作系统的环境变量，以便可以使用 HTTPS_PROXY 加速 gihtub.com/iftechio 下的 repo 下载
+	cmd.Env = os.Environ()
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("%s:\n%s%s", strings.Join(command, " "), stderr.String(), stdout.String())
 	}

--- a/netrc/netrc.go
+++ b/netrc/netrc.go
@@ -1,0 +1,34 @@
+package netrc
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+)
+
+// GenerateDotNetrcFile 生成 .netrc 文件, 用于 github 认证
+func GenerateDotNetrcFile() error {
+	githubTokenLogin := os.Getenv("GITHUB_TOKEN_LOGIN")
+	githubTokenPassword := os.Getenv("GITHUB_TOKEN_PASSWORD")
+	if githubTokenLogin == "" || githubTokenPassword == "" {
+		return errors.New("The env GITHUB_TOKEN_LOGIN or GITHUB_TOKEN_PASSWORD cannot be blank")
+	}
+	bashScript := `
+#!/bin/sh -e
+cat << EOF > /root/.netrc
+machine github.com
+login ${GITHUB_TOKEN_LOGIN}
+password ${GITHUB_TOKEN_PASSWORD}
+EOF
+`
+	command := os.ExpandEnv(bashScript)
+	cmd := exec.Command("/bin/sh", "-c", command)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return errors.New(stderr.String())
+	}
+	return nil
+}

--- a/yaml/goproxy-service.yaml
+++ b/yaml/goproxy-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: goproxy
+  name: goproxy
+  namespace: infra
+spec:
+  ports:
+  - name: http
+    port: 8081
+    protocol: TCP
+    targetPort: 8081
+  selector:
+    app: goproxy
+  sessionAffinity: None
+  type: ClusterIP

--- a/yaml/goproxy.yaml
+++ b/yaml/goproxy.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: goproxy
+  name: goproxy
+  namespace: infra
+spec:
+  serviceName: goproxy
+  replicas: 1
+  selector:
+    matchLabels:
+      app: goproxy
+  template:
+    metadata:
+      labels:
+        app: goproxy
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: role
+                operator: In
+                values:
+                - app
+      automountServiceAccountToken: true
+      containers:
+      - env:
+        - name: HTTPS_PROXY
+          value: http://jike:kYEwE4vnkMoJpWdaG]ANXxxNMenRC@47.52.119.148:4443
+        - name: NO_PROXY
+          value: goproxy.cn,mirrors.aliyun.com
+        - name: GITHUB_TOKEN_LOGIN
+          valueFrom:
+            configMapKeyRef:
+              key: GITHUB_TOKEN_LOGIN
+              name: group.goproxy-config
+        - name: GITHUB_TOKEN_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              key: GITHUB_TOKEN_PASSWORD
+              name: group.goproxy-config
+        image: registry-vpc.cn-hangzhou.aliyuncs.com/iftech/goproxy:fix-env-2c39839
+        imagePullPolicy: IfNotPresent
+        args:
+        - -listen=0.0.0.0:8081
+        - -cacheDir=/ext
+        - -proxy=https://goproxy.cn
+        - -exclude=github.com/iftechio
+        name: rabbitmq
+        ports:
+        - containerPort: 8081
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 300m
+            memory: 1000Mi
+          requests:
+            cpu: 300m
+            memory: 1000Mi
+        volumeMounts:
+        - mountPath: /ext
+          name: goproxy-cache
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 600
+  volumeClaimTemplates:
+  - metadata:
+      name: goproxy-cache
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: alicloud-disk-ssd
+      volumeMode: Filesystem


### PR DESCRIPTION
修改了下 goproxy 项目，用来做我们内部的 goproxy 代理。
主要实现如下的效果：
- 能通过 proxy 对 github 的 private repo 加速。
- 能兼容外部的 proxy（例如 goproxy.cn）对公有的 github repo 加速。
